### PR TITLE
compact size option + add css variables for custom styling

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -3,6 +3,8 @@
     constructor() {
       super()
       this.attachShadow({ mode: 'open' })
+
+      this.size = this.getAttribute('size') || 'full'
     }
 
     async connectedCallback() {
@@ -25,37 +27,73 @@
           return
         }
 
-        const prev = sites[(index - 1 + sites.length) % sites.length]
-        const next = sites[(index + 1) % sites.length]
         const randomUrl = `${apiUrl}/webring?from=${siteId}&to=random`
 
-        this.shadowRoot.innerHTML = `
-          <style>
-            .webring {
-              font-family: sans-serif;
-              background: #fff9d6;
-              border: 1px solid #ffd700;
-              padding: 0.5rem 1rem;
-              display: inline-block;
-              font-size: 0.9rem;
-              border-radius: 6px;
-            }
-            .webring a {
-              color: #b87b00;
-              text-decoration: none;
-              margin: 0 0.4rem;
-            }
-            .webring a:hover {
-              text-decoration: underline;
-            }
-          </style>
-          <div class="webring">
-            <a href="${apiUrl}/webring?from=${siteId}&to=prev">← Prev</a> |
-            Part of <strong>Yellow Brick Ring</strong> |
-            <a href="${apiUrl}/webring?from=${siteId}&to=next">Next →</a> |
-            <a href="${randomUrl}">🎲 Random</a>
-          </div>
-        `
+        if(this.size === 'full') {
+          this.shadowRoot.innerHTML = `
+            <style>
+              .webring {
+                font-family: sans-serif;
+                background: var(--ybr-background-color, #fff9d6);
+                border: 1px solid var(--ybr-border-color, #ffd700); 
+                color: var(--ybr-text-color, #000); 
+                padding: 0.5rem 1rem;
+                display: inline-block;
+                font-size: 0.9rem;
+                border-radius: 6px;
+              }
+              .webring a {
+                color: var(--ybr-link-color, #b87b00);
+                text-decoration: none;
+                margin: 0 0.4rem;
+              }
+              .webring a:hover {
+                text-decoration: underline;
+              }
+            </style>
+            <div class="webring">
+              <a href="${apiUrl}/webring?from=${siteId}&to=prev">← Prev</a> |
+              Part of <strong><a href="${apiUrl}">Yellow Brick Ring</a></strong> |
+              <a href="${apiUrl}/webring?from=${siteId}&to=next">Next →</a> |
+              <a href="${randomUrl}">🎲 Random</a>
+            </div>
+          `
+        } else if(this.size === 'compact') {
+          this.shadowRoot.innerHTML = `
+            <style>
+              .webring {
+                font-family: sans-serif;
+                background: var(--ybr-background-color, #fff9d6);
+                border: 1px solid var(--ybr-border-color, #ffd700); 
+                color: var(--ybr-text-color, #000); 
+                padding: 0.5rem;
+                display: inline-flex;
+                font-size: 0.9rem;
+                border-radius: 6px;
+
+
+              }
+              .webring a {
+                color: var(--ybr-link-color, #b87b00);
+                text-decoration: none;
+                margin: 0 0.4rem;
+              }
+              .webring a:hover {
+                text-decoration: underline;
+              }
+            </style>
+            <div class="webring">
+              <a href="${apiUrl}"><strong>YBR</strong></a>
+              <a href="${apiUrl}/webring?from=${siteId}&to=prev">Prev</a> |
+              <a href="${apiUrl}/webring?from=${siteId}&to=next">Next</a> |
+              <a href="${randomUrl}">Rand</a>
+            </div>
+          `
+        } else {
+          console.error('[YellowBrickRing Widget]', 'invalid "size" attribute')
+          this.renderError('Failed to load webring widget')
+        }
+        
       } catch (err) {
         console.error('[YellowBrickRing Widget]', err)
         this.renderError('Failed to load webring widget')


### PR DESCRIPTION
we only have a single widget layout

it is good for desktop / wide screens but not ideal for mobile

this PR breaks the widget into a 'full' size (original) and a 'compact' size

![Screenshot from 2025-07-08 19-44-01](https://github.com/user-attachments/assets/727eca90-b552-4ffd-ae31-0adabd8c51c7)
![Screenshot from 2025-07-08 19-44-22](https://github.com/user-attachments/assets/e7857487-a9df-46c5-ace8-ac6614e20da2)

it also adds several CSS variables for styling the widget which are hopefully self-explanatory:
* `--ybr-background-color`
* `--ybr-border-color`
* `--ybr-text-color`
* `--ybr-link-color`